### PR TITLE
(hotfix-import-google-font-footer) hotfix split external footer font import

### DIFF
--- a/frontend/src/components/footer/style.css
+++ b/frontend/src/components/footer/style.css
@@ -1,4 +1,6 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@200&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins&display=swap');
 
 .footer {
   font-family: 'Poppins', sans-serif;


### PR DESCRIPTION
Split the external import across this seems to build fine, I have checked to ensure the same fonts are still being imported.