### PR TITLE
Tidying up CSS for article listing and Added links for the single articles

### DIFF
--- a/frontend/src/components/articles/article.js
+++ b/frontend/src/components/articles/article.js
@@ -19,9 +19,15 @@ const Article = ({ id, img_src, tag, tag_meta, date, author, title, desc }) => {
     }
   });
 
+  let colorTheme = myTag === 'emergency' ? '#BF0012'
+  : myTag === 'youth'? '#00A4CB'
+  : myTag === 'parents' ? '#48AB5D'
+  : 'black';
+
+
   return (
 
-    <div>
+    <div class={style.articleContainer}>
       <div class={style.mobileAndFeatureArticleContainer}>
         <div class={style.content}>
           <p
@@ -55,20 +61,12 @@ const Article = ({ id, img_src, tag, tag_meta, date, author, title, desc }) => {
           <img class={style.mainImage} src={img_src} />
           </Link>
           <div class={style.share}>
-            <img src='../../assets/mock-images/share.svg'/>
+            <img src='../../assets/mock-images/share.svg' />
           </div>
         </div>
         <div class={style.content}>
           <p
-            style={
-              myTag === 'emergency'
-                ? { color: '#BF0012' }
-                : myTag === 'youth'
-                ? { color: '#00A4CB' }
-                : myTag === 'parents'
-                ? { color: '#48AB5D' }
-                : { color: 'black' }
-            }
+            style={ { color: colorTheme }}
             class={style.tag}
           >
             <div
@@ -86,42 +84,37 @@ const Article = ({ id, img_src, tag, tag_meta, date, author, title, desc }) => {
           </p>
 
           <div class={style.title}>
+
+          <Link href={`/section/${tag.split(/\W/).join('-').toLowerCase()}/${tag_meta.split(' ').join('-').toLowerCase()}/${title.split(/\W/).join('-')}/${id}`}>
             <span >{title}</span>
+          </Link>
+
           </div>
           <p class={style.desc}>{desc}</p>
           <hr
-            style={
-              myTag === 'emergency'
-                ? { borderColor: '#BF0012' }
-                : myTag === 'youth'
-                ? { borderColor: '#00A4CB' }
-                : myTag === 'parents'
-                ? { borderColor: '#48AB5D' }
-                : { borderColor: 'black' }
-            }
+            style={ {borderColor: colorTheme}}
+
             class={style.hr}
           />
         </div>
       </div>
 
-      <div class={style.desktopArticleContainer}>
+      <div class={style.desktopArticleContainer}
+           style={ { borderBottom: ` solid ${colorTheme}` } }
+      >
         <div class={style.image}>
-          <img class={style.mainImage} src={img_src} />
+
+        <Link href={`/section/${tag.split(/\W/).join('-').toLowerCase()}/${tag_meta.split(' ').join('-').toLowerCase()}/${title.split(/\W/).join('-')}/${id}`}>
+            <img class={style.mainImage} src={img_src} />
+            </Link>
+
           <div class={style.share}>
-            <img src='../../assets/mock-images/share.svg'/>
+            <img src='../../assets/mock-images/share.svg' />
           </div>
         </div>
         <div class={style.content}>
           <p
-            style={
-              myTag === 'emergency'
-                ? { color: '#BF0012' }
-                : myTag === 'youth'
-                ? { color: '#00A4CB' }
-                : myTag === 'parents'
-                ? { color: '#48AB5D' }
-                : { color: 'black' }
-            }
+            style={ { color: colorTheme } }
             class={style.tag}
           >
             <div
@@ -138,22 +131,20 @@ const Article = ({ id, img_src, tag, tag_meta, date, author, title, desc }) => {
             </span>
           </p>
 
+
           <div class={style.title}>
-            <span>{title}</span>
+            
+          <Link href={`/section/${tag.split(/\W/).join('-').toLowerCase()}/${tag_meta.split(' ').join('-').toLowerCase()}/${title.split(/\W/).join('-')}/${id}`}>
+            <span >{title}</span>
+          </Link>
+
           </div>
           <p class={style.desc}>{desc}</p>
-          <hr
-            style={
-              myTag === 'emergency'
-                ? { borderColor: '#BF0012' }
-                : myTag === 'youth'
-                ? { borderColor: '#00A4CB' }
-                : myTag === 'parents'
-                ? { borderColor: '#48AB5D' }
-                : { borderColor: 'black' }
+          {/* <hr
+            style={{ borderColor: colorTheme }
             }
             class={style.hr}
-          />
+          /> */}
         </div>
       </div>
     </div>

--- a/frontend/src/components/articles/style.css
+++ b/frontend/src/components/articles/style.css
@@ -140,8 +140,15 @@
     display:none;
   }
 
+  .articleContainer {
+    height: 100%;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
   .desktopArticleContainer{
     margin: 10px;
+    height: 100%;
   }
 
   .desktopArticleContainer .image {
@@ -155,7 +162,7 @@
     width: 100%;
     height: 100%;
     /* object-fit: cover; */
-  
+
   }
 
   .desktopArticleContainer .share {
@@ -191,6 +198,11 @@
 
   .desktopArticleContainer .content .byline{
     color:#6B6B6B;
+  }
+
+  .desktopArticleContainer .title a{
+    text-decoration: none;
+    color: black;
   }
 }
 
@@ -242,7 +254,7 @@
   .desktopArticleContainer{
     display:none;
   }
-  
+
   .mobileAndFeatureArticleContainer {
     display: none;
   }
@@ -259,7 +271,7 @@
   }
 
   .tabletArticleContainer .content{
-    text-align: left; 
+    text-align: left;
   }
 
   .tabletArticleContainer .content .tag{
@@ -293,7 +305,7 @@
     width: 100%;
     height: 100%;
     /* object-fit: cover; */
-  
+
   }
 
   .tabletArticleContainer .share {
@@ -342,7 +354,7 @@
   .desktopArticleContainer{
     display: none;
   }
-  
+
   .tabletArticleContainer {
     display: none;
   }
@@ -397,6 +409,11 @@
 
 /* MOBILE ARTICLE COMPONENT */
 @media only screen and (min-device-width: 300px) and (max-width: 600px) {
+
+  .desktopArticleContainer {
+    display: none;
+  }
+
   .mobileAndFeatureArticleContainer {
     display: flex;
     flex-direction: row;
@@ -439,11 +456,19 @@
   }
 }
 
+
 /* FEATURE PHONE ARTICLES VIEW COMPONENT */
 @media only screen and (max-device-width: 300px) {
+
   .desktopArticleContainer{
-    display:none;
+    display: none;
   }
+
+  .tabletArticleContainer {
+    display: none;
+  }
+
+
 
   .tabletArticles {
     display: none;
@@ -514,6 +539,10 @@
     display: none;
   }
 
+  .desktopArticleContainer {
+    display: none;
+  }
+
   .mobileAndFeatureArticleContainer {
     display: flex;
     flex-direction: row;
@@ -521,6 +550,7 @@
     align-items: center;
     border-bottom: 1px solid #dadada;
     padding: 0 12px;
+    width: 100vw;
   }
 
   .mobileAndFeatureArticleContainer .title {

--- a/frontend/src/components/header/style.css
+++ b/frontend/src/components/header/style.css
@@ -411,7 +411,7 @@
     box-shadow: 0 0 1px rgba(0, 0, 0, 0.25);
     width: 100vw;
     margin: auto;
-    z-index: 1;
+    z-index: 200;
     text-align: left;
     white-space: nowrap;
     text-align: center;
@@ -450,6 +450,7 @@
 
   .language-dropdown:hover .language-dropdown-content {
     display: block;
+    z-index: 200;
   }
 
   .search-menu > a {
@@ -767,6 +768,7 @@ with similar viewport measurments ***************************
     display: inline-block;
     margin-left: 60px; /* allows margin at beginning of flex box*/
     padding-bottom: 13px;
+    z-index: 200;
   }
   .categories-dropdown .btn-group {
     display: inline-block;
@@ -906,6 +908,7 @@ with similar viewport measurments ***************************
     font-weight: 600;
     color: #6b6b6b;
     padding-left: 5px;
+    z-index: 200;
   }
   .nav .language-dropdown a {
     padding: 0;
@@ -1176,6 +1179,7 @@ DESKTOP CSS SETTTINGS. At this point, able to reuse some of the sections and inc
     padding-right: 20px;
     padding-top: 5px;
     font-size: 14px;
+    z-index: 200;
   }
 
   .categories-dropdown .btn-group {
@@ -1314,6 +1318,7 @@ DESKTOP CSS SETTTINGS. At this point, able to reuse some of the sections and inc
     font-size: 12px;
     font-weight: 600;
     color: #6b6b6b;
+    z-index: 200;
   }
 
   .nav .language-dropdown a {


### PR DESCRIPTION
As Brian and I were working on different sections at the same time, there were some overlapping, so just adjusted things so more seamless:
Fixes: 
- adjusted  z-index for drop down menus (was overlapping with article share buttons)
- added article listing border bottom css (so line can appear on the same level wen viewing the article listing)
- added links that lead to the single article for desktop/ tablet (previously only added to mobile/ feature) - single article can now be accessed by clicking on article image or title
- fixed some media query clashes in article listings where feature phone and desktop article media queries seemed to overlap (as of now seems the feature phone css is still a bit off from original demonstration, so will consult with Brian on this matter)