### PR TITLE
stop git treating PNGs as text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.png -text


### PR DESCRIPTION
On my Linux machine, a clean checkout of the develop branch results in pretty much all PNG files being modified locally because git is treating PNG image files as text and attempting to convert what look like line endings within those files. This addition to `.gitattributes` will make git treat PNGs as binary files, and leave them alone.